### PR TITLE
Prevent notify_gauge/1 etc. from crashing

### DIFF
--- a/src/quintana.erl
+++ b/src/quintana.erl
@@ -84,7 +84,14 @@ notify(Fun, {Name, Value, Type, Attrs}) ->
             ok
     end;
 notify(Fun, {Name, Value}) ->
-    notify(Fun, Name, Value).
+    notify(Fun, Name, Value);
+notify(Fun, Name) ->
+    case folsom_metrics:safely_notify(Name) of
+        {error, Name, nonexistent_metric} ->
+            folsom_metrics:Fun(Name);
+        ok ->
+            ok
+    end.
 
 notify(Fun, Name, Value) ->
     case folsom_metrics:safely_notify(Name, Value) of


### PR DESCRIPTION
@puzza007 This should make `notify_gauge` and `notify_counter` work. 

```
** Reason for termination =
** {function_clause,
       [{quintana,notify,
            [new_gauge,<<"foo.bar.moo">>],
            [{file,"src/quintana.erl"},{line,78}]},
        {freya_tcp_client,connected,2,
            [{file,"src/profkinera.erl"},{line,108}]},
        {gen_fsm,handle_msg,7,[{file,"gen_fsm.erl"},{line,505}]},
        {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
```